### PR TITLE
Allows >= rest-client 1.4.x

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ begin
 
     s.add_dependency 'json_pure', '>= 1.2.0', '< 1.5.0'
     s.add_dependency 'sinatra', '~> 1.0.0'
-    s.add_dependency 'rest-client', '~> 1.4.0'
+    s.add_dependency 'rest-client', '>= 1.4.0'
     s.add_dependency 'sequel', '~> 3.15.0'
     s.add_dependency 'sqlite3-ruby', '~> 1.2'
     s.add_dependency 'rack', '>= 1.0.1'

--- a/taps.gemspec
+++ b/taps.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Ricardo Chimal, Jr."]
-  s.date = %q{2010-09-10}
+  s.date = %q{2010-09-25}
   s.description = %q{A simple database agnostic import/export app to transfer data to/from a remote database.}
   s.email = %q{ricardo@heroku.com}
   s.executables = ["taps", "schema"]
@@ -49,32 +49,32 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{taps}
-  s.rubygems_version = %q{1.3.6}
+  s.rubygems_version = %q{1.3.7}
   s.summary = %q{simple database import/export app}
   s.test_files = [
-    "spec/base.rb",
-     "spec/cli_spec.rb",
-     "spec/data_stream_spec.rb",
+    "spec/utils_spec.rb",
      "spec/operation_spec.rb",
+     "spec/base.rb",
      "spec/server_spec.rb",
-     "spec/utils_spec.rb"
+     "spec/cli_spec.rb",
+     "spec/data_stream_spec.rb"
   ]
 
   if s.respond_to? :specification_version then
     current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
     s.specification_version = 3
 
-    if Gem::Version.new(Gem::RubyGemsVersion) >= Gem::Version.new('1.2.0') then
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<json_pure>, [">= 1.2.0", "< 1.5.0"])
       s.add_runtime_dependency(%q<sinatra>, ["~> 1.0.0"])
-      s.add_runtime_dependency(%q<rest-client>, ["~> 1.4.0"])
+      s.add_runtime_dependency(%q<rest-client>, [">= 1.4.0"])
       s.add_runtime_dependency(%q<sequel>, ["~> 3.15.0"])
       s.add_runtime_dependency(%q<sqlite3-ruby>, ["~> 1.2"])
       s.add_runtime_dependency(%q<rack>, [">= 1.0.1"])
     else
       s.add_dependency(%q<json_pure>, [">= 1.2.0", "< 1.5.0"])
       s.add_dependency(%q<sinatra>, ["~> 1.0.0"])
-      s.add_dependency(%q<rest-client>, ["~> 1.4.0"])
+      s.add_dependency(%q<rest-client>, [">= 1.4.0"])
       s.add_dependency(%q<sequel>, ["~> 3.15.0"])
       s.add_dependency(%q<sqlite3-ruby>, ["~> 1.2"])
       s.add_dependency(%q<rack>, [">= 1.0.1"])
@@ -82,7 +82,7 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<json_pure>, [">= 1.2.0", "< 1.5.0"])
     s.add_dependency(%q<sinatra>, ["~> 1.0.0"])
-    s.add_dependency(%q<rest-client>, ["~> 1.4.0"])
+    s.add_dependency(%q<rest-client>, [">= 1.4.0"])
     s.add_dependency(%q<sequel>, ["~> 3.15.0"])
     s.add_dependency(%q<sqlite3-ruby>, ["~> 1.2"])
     s.add_dependency(%q<rack>, [">= 1.0.1"])


### PR DESCRIPTION
The current gemspec only allows 1.4.x. This means I cannot load this library (and others dependent on it like the heroku gem) while at the same time loading a more recent rest-client.

So I have updated the spec to say >= 1.4 (since 1.4 is still compatible but the latest also seems to run without any test failures).

The rest of the changes of this commit are simply a result of me re-generating the gemspec using the Jewler rake tasks.
