### PR TITLE
Sqlite length error

### DIFF
--- a/lib/taps/data_stream.rb
+++ b/lib/taps/data_stream.rb
@@ -78,7 +78,10 @@ class DataStream
     ds = table.order(*order_by).limit(state[:chunksize], state[:offset])
     log.debug "DataStream#fetch_rows SQL -> #{ds.sql}"
     rows = Taps::Utils.format_data(ds.all,
-      :string_columns => string_columns)
+      :string_columns => string_columns,
+      :schema => db.schema(table_name),
+      :table  => table_name
+    )
     update_chunksize_stats
     rows
   end

--- a/lib/taps/errors.rb
+++ b/lib/taps/errors.rb
@@ -4,10 +4,12 @@ module Taps
 
     def initialize(message, opts={})
       @original_backtrace = opts.delete(:backtrace)
+      super(message)
     end
   end
 
   class NotImplemented < BaseError; end
   class DuplicatePrimaryKeyError < BaseError; end
   class CorruptedData < BaseError; end
+  class InvalidData < BaseError; end
 end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -12,6 +12,12 @@ describe Taps::Utils do
     Taps::Utils.format_data([ first_row, { :x => 2, :y => 2 } ]).should == { :header => [ :x, :y ], :data => [ [1, 1], [2, 2] ] }
   end
 
+  it "enforces length limitations on columns" do
+    data = [ { :a => "aaabbbccc" } ]
+    schema = [ [ :a, { :db_type => "varchar(3)" }]]
+    lambda { Taps::Utils.format_data(data, :schema => schema) }.should.raise(Taps::InvalidData)
+  end
+
   it "scales chunksize down slowly when the time delta of the block is just over a second" do
     Time.stubs(:now).returns(10.0).returns(11.5)
     Taps::Utils.calculate_chunksize(1000) { }.should == 900


### PR DESCRIPTION
Adds an error message when there is data that exceeds column restrictions
