### PR TITLE
Fixed mysql tinyint length error

### DIFF
--- a/lib/taps/data_stream.rb
+++ b/lib/taps/data_stream.rb
@@ -218,6 +218,7 @@ class DataStream
   def self.factory(db, state)
     if defined?(Sequel::MySQL) && Sequel::MySQL.respond_to?(:convert_invalid_date_time=)
       Sequel::MySQL.convert_invalid_date_time = :nil
+      Sequel::MySQL.convert_tinyint_to_bool = false      
     end
 
     if state.has_key?(:klass)


### PR DESCRIPTION
Hey Ricardo, can you please check out this fix of mine? I've been experiencing a bug when trying to convert a mysql table that uses tinyint into a sqlite3 database. Recent versions of Sequel convert tinyints into booleans. your code then converts these into the strings "true" or "false", which are too long for the tinyint field length of 1, which causes a length error. This patch tells Sequel not to interpret tinyints as booleans.

Thanks,
Carl
