### PR TITLE
Performance degradation on large tables is the mind killer

### DIFF
--- a/lib/taps/operation.rb
+++ b/lib/taps/operation.rb
@@ -479,16 +479,15 @@ class Push < Operation
       chunksize = stream.state[:chunksize]
 
       begin
-        chunksize = Taps::Utils.calculate_chunksize(chunksize) do |c|
-          stream.state[:chunksize] = c
-          encoded_data, row_size, elapsed_time = stream.fetch
-          break if stream.complete?
+        stream.state[:chunksize] = chunksize
+        encoded_data, row_size, elapsed_time = stream.fetch
+        break if stream.complete?
+        data = {
+          :state => stream.to_hash,
+          :checksum => Taps::Utils.checksum(encoded_data).to_s
+        }
 
-          data = {
-            :state => stream.to_hash,
-            :checksum => Taps::Utils.checksum(encoded_data).to_s
-          }
-
+        chunksize = Taps::Utils.calculate_chunksize(chunksize) do
           begin
             content, content_type = Taps::Multipart.create do |r|
               r.attach :name => :encoded_data,


### PR DESCRIPTION
In db:push, the calculate_chunksize block includes the stream.fetch call.  In the case where the stream is a DB (the common case, if not all) this means that increasing seek time for larger offsets throwing off the chunksize calculation, resulting in ever-smaller chunks, until you're doing a whole lot of seeking and very little transmitting.

Solved by taking the stream.fetch call out of the chunksize calculation block, which means the newly-calculated chunksize is used on the next operation, rather than the current one, but then again only includes transmit time, rather than seek time.  Thus, the chunksize calculator does its job, which is (I guess) reacting to varying network connectivity to avoid timeouts from overly-large chunksizes.

The change might need some tweaks, but AFAICT the gist is right.
