### PR TITLE
Exclude Tables

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -29,6 +29,11 @@ or when you want to transfer a list of tables
 or when you want to transfer tables that start with a word
 
   $ taps push postgres://dbuser:dbpassword@localhost/dbname http://httpuser:httppassword@example.com:5000 --filter '^log_'
+  
+or when you want to transfer all tables except a list of given tables
+
+$ taps push postgres://dbuser:dbpassword@localhost/dbname http://httpuser:httppassword@example.com:5000 --exclude_tables logs,tags
+
 
 == Known Issues
 

--- a/lib/taps/cli.rb
+++ b/lib/taps/cli.rb
@@ -137,6 +137,7 @@ EOHELP
         r_tables = v.collect { |t| "^#{t}$" }.join("|")
         opts[:table_filter] = "(#{r_tables})"
       end
+      o.on("-e", "--exclude_tables=A,B,C", Array, "Shortcut to exclude a list of tables") {|v| opts[:exclude_tables] = v}
       o.on("-d", "--debug", "Enable Debug Messages") { |v| opts[:debug] = true }
       o.parse!(argv)
 

--- a/lib/taps/operation.rb
+++ b/lib/taps/operation.rb
@@ -36,20 +36,25 @@ class Operation
   def table_filter
     opts[:table_filter]
   end
+  
+  def exclude_tables
+    opts[:exclude_tables] || []
+  end
 
   def apply_table_filter(tables)
-    return tables unless table_filter
-    re = Regexp.new(table_filter)
+    return tables unless table_filter || exclude_tables
+    
+    re = table_filter ? Regexp.new(table_filter) : nil
     if tables.kind_of?(Hash)
       ntables = {}
       tables.each do |t, d|
-        unless re.match(t.to_s).nil?
+        if !exclude_tables.include?(t.to_s) && (!re || !re.match(t.to_s).nil?)
           ntables[t] = d
         end
       end
       ntables
     else
-      tables.reject { |t| re.match(t.to_s).nil? }
+      tables.reject { |t| exclude_tables.include?(t.to_s) || (re && re.match(t.to_s).nil?) }
     end
   end
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -7,4 +7,10 @@ describe Taps::Cli do
     opts = @cli.clientoptparse(:pull)
     opts[:table_filter].should == "(^mytable1$|^logs$)"
   end
+  
+  it "translates a list of tables to exclude into a regex that can be used in table_filter" do
+    @cli = Taps::Cli.new(["-e", "mytable1,logs", "sqlite://tmp.db", "http://x:y@localhost:5000"])
+    opts = @cli.clientoptparse(:pull)
+    opts[:exclude_tables].should == ['mytable1','logs']
+  end
 end

--- a/spec/operation_spec.rb
+++ b/spec/operation_spec.rb
@@ -10,11 +10,22 @@ describe Taps::Operation do
     @op = Taps::Operation.new('dummy://localhost', 'http://x:y@localhost:5000', :table_filter => 'abc')
     @op.apply_table_filter(['abc', 'def']).should == ['abc']
   end
-
+  
   it "returns a hash of tables that match the regex table_filter" do
     @op = Taps::Operation.new('dummy://localhost', 'http://x:y@localhost:5000', :table_filter => 'abc')
     @op.apply_table_filter({ 'abc' => 1, 'def' => 2 }).should == { 'abc' => 1 }
   end
+  
+  it "returns an array of tables without the exclude_tables tables" do
+    @op = Taps::Operation.new('dummy://localhost', 'http://x:y@localhost:5000', :exclude_tables => ['abc', 'ghi', 'jkl'])
+    @op.apply_table_filter(['abc', 'def', 'ghi', 'jkl', 'mno']).should == ['def', 'mno']
+  end
+
+  it "returns a hash of tables without the exclude_tables tables" do
+    @op = Taps::Operation.new('dummy://localhost', 'http://x:y@localhost:5000', :exclude_tables => ['abc', 'ghi', 'jkl'])
+    @op.apply_table_filter({ 'abc' => 1, 'def' => 2, 'ghi' => 3, 'jkl' => 4, 'mno' => 5 }).should == { 'def' => 2, 'mno' => 5 }
+  end
+
 
   it "masks a url's password" do
     @op.safe_url("mysql://root:password@localhost/mydb").should == "mysql://root:[hidden]@localhost/mydb"


### PR DESCRIPTION
Hey guys,

at kopfmaschine we really love taps due to it's ease of use when transfering data from one machine to another! But lately we were facing the same problem again and again: how can we assure that certain tables are NOT included in an operation?

Regular Expressions used for the "--filter" argument are making it really hard to such an exclude. Therefore I've added the new "--exclude_tables" option that allows one to explicitly exclude a set of tables from any operation.

All the best from Bremen/Germany and keep up the good work!

Thorben
- kopfmaschine
