### PR TITLE
Option to skip schema transfer

### DIFF
--- a/lib/taps/cli.rb
+++ b/lib/taps/cli.rb
@@ -128,6 +128,7 @@ EOHELP
         o.define_head "Push a database to a taps server"
       end
 
+      o.on(      '--no-schema', "Don't transfer the schema, just data") {|v| opts[:no_schema] = true }
       o.on("-i", "--indexes-first", "Transfer indexes first before data") { |v| opts[:indexes_first] = true }
       o.on("-r", "--resume=file", "Resume a Taps Session from a stored file") { |v| opts[:resume_filename] = v }
       o.on("-c", "--chunksize=N", "Initial Chunksize") { |v| opts[:default_chunksize] = (v.to_i < 10 ? 10 : v.to_i) }

--- a/lib/taps/operation.rb
+++ b/lib/taps/operation.rb
@@ -29,6 +29,10 @@ class Operation
     "op"
   end
 
+  def skip_schema?
+    !!opts[:no_schema]
+  end
+
   def indexes_first?
     !!opts[:indexes_first]
   end
@@ -236,7 +240,7 @@ class Pull < Operation
   def run
     catch_errors do
       unless resuming?
-        pull_schema
+        pull_schema unless skip_schema?
         pull_indexes if indexes_first?
       end
       setup_signal_trap
@@ -395,13 +399,13 @@ class Push < Operation
   def run
     catch_errors do
       unless resuming?
-        push_schema
-        push_indexes if indexes_first?
+        push_schema unless skip_schema?
+        push_indexes if indexes_first? && !skip_schema?
       end
       setup_signal_trap
       push_partial_data if resuming?
       push_data
-      push_indexes unless indexes_first?
+      push_indexes unless indexes_first? || skip_schema?
       push_reset_sequences
     end
   end


### PR DESCRIPTION
I have had to migrate mysql to oracle several times and previously couldn't do it with taps because the schema just doesn't transfer, I guess sequel can't represent the schema properly to oracle. So I just use rails db:schema:load and then want to use taps to transfer the data. I added a --no-schema flag to enable that.
