### PR TITLE
updating Gemfile for warning message received when gem installing taps 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "rack",          ">= 1.0.1"
 gem "rest-client",   ">= 1.4.0", "< 1.7.0"
 gem "sequel",        "~> 3.20.0"
 gem "sinatra",       "~> 1.0.0"
-gem "sqlite3-ruby" , "~> 1.2"
+gem "sqlite3" , "~> 1.2"
 
 group :development do
   gem "bacon"


### PR DESCRIPTION
###### 

Hello! The sqlite3-ruby gem has changed it's name to just sqlite3.  Rather than
installing `sqlite3-ruby`, you should install `sqlite3`.  Please update your
dependencies accordingly.

Thanks from the Ruby sqlite3 team!

<3 <3 <3 <3
###### 
