### PR TITLE
Bugfix: single_integer_primary_key on multi-column PKs

### DIFF
--- a/lib/taps/utils.rb
+++ b/lib/taps/utils.rb
@@ -139,8 +139,8 @@ Data   : #{data}
 
   def single_integer_primary_key(db, table)
     table = table.to_sym.identifier unless table.kind_of?(Sequel::SQL::Identifier)
-    keys = db.schema(table).select { |c| c[1][:primary_key] and c[1][:type] == :integer }
-    not keys.nil? and keys.size == 1
+    keys = db.schema(table).select { |c| c[1][:primary_key] }
+    not keys.nil? and keys.size == 1 and keys[0][1][:type] == :integer
   end
 
   def order_by(db, table)

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -26,5 +26,14 @@ describe Taps::Utils do
     ])
     Taps::Utils.incorrect_blobs(@db, :mytable).should == [:mytext]
   end
+
+  it "rejects a multiple-column primary key as a single integer primary key" do
+    @db = mock("db", :url => "mysql://localhost/pkdb")
+    @db.stubs(:schema).with(:pktable.identifier).returns([
+      [:id1, { :primary_key => true, :type => :integer }],
+      [:id2, { :primary_key => true, :type => :string }]
+    ])
+    Taps::Utils.single_integer_primary_key(@db, :pktable).should.be.false
+  end
 end
 


### PR DESCRIPTION
single_integer_primary_key returned true if a primary key had exactly one integer-valued column, even if it was part of a multiple column key.  This caused a problem later, when Taps used DataStreamKeyed, rather than DataStream, if the first of the columns was not numeric.

First commit adds the fix.
Second commit adds a regression test.
