### PR TITLE
Sequel version: bump to >= 3.20.0

### DIFF
--- a/bin/schema
+++ b/bin/schema
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'rubygems'
-gem 'sequel', '~> 3.20.0'
+gem 'sequel', '>= 3.20.0'
 
 $:.unshift File.dirname(__FILE__) + '/../lib'
 

--- a/taps.gemspec
+++ b/taps.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "rack",          ">= 1.0.1"
   gem.add_dependency "rest-client",   ">= 1.4.0", "< 1.7.0"
-  gem.add_dependency "sequel",        "~> 3.20.0"
+  gem.add_dependency "sequel",        ">= 3.20.0"
   gem.add_dependency "sinatra",       "~> 1.0.0"
   gem.add_dependency "sqlite3-ruby",  "~> 1.2"
 


### PR DESCRIPTION
Versions of Sequel above 3.20.x added support for TinyTDS as one of the
adapter types.  Changed the version spec to use '>=' rather than '~>'.
