### PR TITLE
Add a meaningful error message for probable Ruby version mismatch.

### DIFF
--- a/lib/taps/operation.rb
+++ b/lib/taps/operation.rb
@@ -213,6 +213,10 @@ class Operation
         puts "!!! Caught Server Exception"
         puts "HTTP CODE: #{e.http_code}"
         puts "#{e.response.to_s}"
+        if e.response.to_s['time zone displacement out of range']
+          puts "Are you using the same Ruby version on client and server?"
+          puts "Heroku Bamboo and Cedar use 1.9.2, you are using #{RUBY_VERSION}"
+        end
         exit(1)
       else
         raise


### PR DESCRIPTION
New +1's are added to Issue #92 every other day. While it is hard to really fix it and actually make taps work right with different Ruby versions on client and server, it is easy to add a small message that may save people a lot of time.

This small patch adds an error message that tells the user to switch their Ruby version to 1.9.2 when using the Heroku stacks. It gets displayed when the server response contains the main (only?) symptom of the mismatch, a time zone displacement error.
