### PR TITLE
Use any 1.x version of Sinatra

### DIFF
--- a/taps.gemspec
+++ b/taps.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rack",          ">= 1.0.1"
   gem.add_dependency "rest-client",   ">= 1.4.0", "< 1.7.0"
   gem.add_dependency "sequel",        "~> 3.20.0"
-  gem.add_dependency "sinatra",       "~> 1.0.0"
+  gem.add_dependency "sinatra",       "~> 1"
   gem.add_dependency "sqlite3-ruby",  "~> 1.2"
 
   gem.add_development_dependency "bacon"


### PR DESCRIPTION
This issue is similar to #81, but is just a bit more elegant - rather than dropping all the version information from the gemspec, I've just bumped the Sinatra version dependency to any 1.x release and run all the specs to make sure everything still behaves as expected - I've also been using my taps repository within my application to perform `heroku db:pull`'s and `push`'s without any problems.

This problem's bitten me quite a few times now, as it occurs not just for my own Sinatra applications running version 1.3.2, but also affects other gems that internally use Sinatra, such as https://github.com/defunkt/resque.
