### PR TITLE
Bugfix: always wrote "ETA:  00:00:00"

### DIFF
--- a/lib/taps/operation.rb
+++ b/lib/taps/operation.rb
@@ -355,7 +355,7 @@ class Pull < Operation
     apply_table_filter(tables).each do |table_name|
       retries = 0
       begin
-        count = session_resource['pull/table_count'].post({:table => table_name}, http_headers).to_s.to_i
+        count = Integer(session_resource['pull/table_count'].post({:table => table_name}, http_headers).to_s)
         data[table_name] = count
       rescue RestClient::Exception
         retries += 1


### PR DESCRIPTION
Use Integer() instead of to_i to fix a bug using Heroku cli that ended writting "ETA:  00:00:00" all along.
The to_s.to_i was always returning 200 even if the to_s was returning "1234567".
