### PR TITLE
Update gemspec to be less specific on versions.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,44 +2,57 @@ PATH
   remote: .
   specs:
     taps (0.3.23)
-      rack (>= 1.0.1)
-      rest-client (>= 1.4.0, < 1.7.0)
-      sequel (~> 3.20.0)
-      sinatra (~> 1.0.0)
+      rack (>= 1)
+      rest-client (>= 1.4, < 1.7)
+      sequel (~> 3.35)
+      sinatra (~> 1)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.0.5)
+    activesupport (3.2.3)
+      i18n (~> 0.6)
+      multi_json (~> 1.0)
     bacon (1.1.0)
     builder (3.0.0)
-    daemons (1.1.0)
+    daemons (1.1.8)
     eventmachine (0.12.10)
     extlib (0.9.15)
-    hoptoad_notifier (2.4.7)
+    hoptoad_notifier (2.4.11)
       activesupport
       builder
+    i18n (0.6.0)
+    metaclass (0.0.1)
     mime-types (1.18)
-    mocha (0.9.8)
-      rake
+    mocha (0.11.4)
+      metaclass (~> 0.0.1)
+    multi_json (1.3.5)
     mysql (2.8.1)
     mysql2 (0.2.6)
     pg (0.9.0)
-    rack (1.2.1)
-    rack-test (0.5.7)
+    rack (1.4.1)
+    rack-protection (1.2.0)
+      rack
+    rack-test (0.6.1)
       rack (>= 1.0)
-    rake (0.8.7)
-    rcov (0.9.9)
+    rake (0.9.2.2)
     rest-client (1.6.7)
       mime-types (>= 1.16)
-    sequel (3.20.0)
-    sinatra (1.0)
-      rack (>= 1.0)
+    sequel (3.35.0)
+    simplecov (0.6.4)
+      multi_json (~> 1.0)
+      simplecov-html (~> 0.5.3)
+    simplecov-html (0.5.3)
+    sinatra (1.3.2)
+      rack (~> 1.3, >= 1.3.6)
+      rack-protection (~> 1.2)
+      tilt (~> 1.3, >= 1.3.3)
     sqlite3 (1.3.6)
-    thin (1.2.7)
+    thin (1.3.1)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
       rack (>= 1.0.0)
+    tilt (1.3.3)
 
 PLATFORMS
   ruby
@@ -54,7 +67,7 @@ DEPENDENCIES
   pg (= 0.9.0)
   rack-test
   rake
-  rcov
+  simplecov
   sqlite3 (~> 1.2)
   taps!
   thin (> 1.2.0)

--- a/taps.gemspec
+++ b/taps.gemspec
@@ -13,16 +13,16 @@ Gem::Specification.new do |gem|
 
   gem.files = Dir["**/*"].select { |d| d =~ %r{^(README|VERSION|bin/|data/|ext/|lib/|spec/|test/)} }
 
-  gem.add_dependency "rack",          ">= 1.0.1"
-  gem.add_dependency "rest-client",   ">= 1.4.0", "< 1.7.0"
-  gem.add_dependency "sequel",        "~> 3.20.0"
-  gem.add_dependency "sinatra",       "~> 1.0.0"
+  gem.add_dependency "rack",          ">= 1"
+  gem.add_dependency "rest-client",   ">= 1.4", "< 1.7"
+  gem.add_dependency "sequel",        "~> 3.35"
+  gem.add_dependency "sinatra",       "~> 1"
 
   gem.add_development_dependency "sqlite3", "~> 1.2"
   gem.add_development_dependency "bacon"
   gem.add_development_dependency "mocha"
   gem.add_development_dependency "rack-test"
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "rcov"
+  gem.add_development_dependency "simplecov"
 end
 


### PR DESCRIPTION
This allows for greater compatibility with other gems and projects. There are a few pull requests that are doing something similar for certain gems, such as sinatra, rack and sequel. 

This covers all three of those and also allows for development in Ruby 1.9 by using simplecov instead of rcov which has been deprecated.
