### PR TITLE
Newer Sinatra compatibility

### DIFF
--- a/taps.gemspec
+++ b/taps.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rack",          ">= 1.0.1"
   gem.add_dependency "rest-client",   ">= 1.4.0", "< 1.7.0"
   gem.add_dependency "sequel",        "~> 3.20.0"
-  gem.add_dependency "sinatra",       "~> 1.0.0"
+  gem.add_dependency "sinatra",       "~> 1.0"
 
   gem.add_development_dependency "sqlite3", "~> 1.2"
   gem.add_development_dependency "bacon"


### PR DESCRIPTION
Hi Ricardo,

I modified the sinatra dependency to accept newer sinatra gems... One of my other gems needed Sinatra 1.3.3... and the taps was constraining sinatra to 1.0.0

This was the message:

```
Bundler could not find compatible versions for gem "sinatra":
```

       In Gemfile:
        taps (>= 0.3.24) ruby depends on
          sinatra (~> 1.0.0) ruby

```
    split (>= 0) ruby depends on
```

           sinatra (1.3.3)
