### PR TITLE
Fixed the progress bar when pulling the schema

### DIFF
--- a/lib/taps/operation.rb
+++ b/lib/taps/operation.rb
@@ -264,7 +264,8 @@ class Pull < Operation
       schema_data = session_resource['pull/schema'].post({:table_name => table_name}, http_headers).to_s
       log.debug "Table: #{table_name}\n#{schema_data}\n"
       output = Taps::Utils.load_schema(database_url, schema_data)
-      puts output if output
+      output = output.to_s.strip
+      puts output unless output.empty?
       progress.inc(1)
     end
     progress.finish


### PR DESCRIPTION
The output (wehn pulling data) used to be:

```
Receiving schema
Schema:          0% |                                          | ETA:  --:--:--
Schema:          1% |                                          | ETA:  00:01:32
Schema:          3% |=                                         | ETA:  00:01:28
Schema:          5% |==                                        | ETA:  00:01:28
Schema:          6% |==                                        | ETA:  00:01:25
Schema:          8% |===                                       | ETA:  00:01:23
Schema:         10% |====                                      | ETA:  00:01:21
Schema:         11% |====                                      | ETA:  00:01:19
Schema:         13% |=====                                     | ETA:  00:01:17
Schema:         15% |======                                    | ETA:  00:01:32
Schema:         16% |======                                    | ETA:  00:01:28
Schema:         18% |=======                                   | ETA:  00:01:25
Schema:         20% |========                                  | ETA:  00:01:27
Schema:         22% |=========                                 | ETA:  00:01:24
Schema:         23% |=========                                 | ETA:  00:01:21
Schema:         25% |==========                                | ETA:  00:01:19
Schema:         27% |===========                               | ETA:  00:01:17
```

It is now fixed:

```
Receiving schema
Schema:         27% |===========                               | ETA:  00:01:17
```
