### PR TITLE
Ensure Taps version of OkJson is used to properly encode data

### DIFF
--- a/lib/taps/server.rb
+++ b/lib/taps/server.rb
@@ -31,7 +31,7 @@ class Server < Sinatra::Base
     end
     if e.kind_of?(Taps::BaseError)
       content_type "application/json"
-      halt 412, OkJson.encode({ 'error_class' => e.class.to_s, 'error_message' => e.message, 'error_backtrace' => e.backtrace.join("\n") })
+      halt 412, ::OkJson.encode({ 'error_class' => e.class.to_s, 'error_message' => e.message, 'error_backtrace' => e.backtrace.join("\n") })
     else
       "Taps Server Error: #{e}\n#{e.backtrace}"
     end
@@ -48,7 +48,7 @@ class Server < Sinatra::Base
 
   get '/health' do
     content_type 'application/json'
-    OkJson.encode({ :ok => true })
+    ::OkJson.encode({ :ok => true })
   end
 
   get '/' do
@@ -85,7 +85,7 @@ class Server < Sinatra::Base
     end
 
     content_type 'application/json'
-    OkJson.encode({ :state => stream.to_hash })
+    ::OkJson.encode({ :state => stream.to_hash })
   end
 
   post '/sessions/:key/push/table' do
@@ -154,7 +154,7 @@ class Server < Sinatra::Base
     end
 
     content_type 'application/json'
-    OkJson.encode(tables)
+    ::OkJson.encode(tables)
   end
 
   post '/sessions/:key/pull/table_count' do
@@ -176,13 +176,13 @@ class Server < Sinatra::Base
     stream = nil
 
     session.conn do |db|
-      state = OkJson.decode(params[:state]).symbolize_keys
+      state = ::OkJson.decode(params[:state]).symbolize_keys
       stream = Taps::DataStream.factory(db, state)
       encoded_data = stream.fetch.first
     end
 
     checksum = Taps::Utils.checksum(encoded_data).to_s
-    json = OkJson.encode({ :checksum => checksum, :state => stream.to_hash })
+    json = ::OkJson.encode({ :checksum => checksum, :state => stream.to_hash })
 
     content, content_type_value = Taps::Multipart.create do |r|
       r.attach :name => :encoded_data,


### PR DESCRIPTION
Taps uses a customized version of OkJson to exchange data between the client
and server. This customized version silently converts symbols to strings
as a convience (the original OkJson considers encoding symbols an error since
symbols are not a type supported by JSON).

Rack started using OkJson also to encode data but kept the original symantics.
Since the Taps::Server inherits from Sinatra::Base, and Sinatra::Base includes
Rack::Utils, and Rack::Utils is the namespace where Rack's version of OkJson
is installed this means the Rack version is now being used by taps instead of
the taps version. This means when symbols are encoded an error is generated.

To restore the original behavior this patch explicility references the taps
version of OkJson.

This fixes issue #128.
