### PR TITLE
Swtich from removed `Config` to `RbConfig`

### DIFF
--- a/lib/taps/utils.rb
+++ b/lib/taps/utils.rb
@@ -14,7 +14,7 @@ module Utils
   def windows?
     return @windows if defined?(@windows)
     require 'rbconfig'
-    @windows = !!(::Config::CONFIG['host_os'] =~ /mswin|mingw/)
+    @windows = !!(RbConfig::CONFIG['host_os'] =~ /mswin|mingw/)
   end
 
   def bin(cmd)


### PR DESCRIPTION
If you wanted to support older versions of Ruby you could test if `RbConfig` was defined and use `Config` if it was not. But `Config` has been deprecated for a while so not sure if it's really necessary to support it anymore so going with the simpler patch. This fixes #143.
